### PR TITLE
Open Beta - changes - fall back to origin/branch if branch is not found

### DIFF
--- a/check-pr/index.js
+++ b/check-pr/index.js
@@ -79,8 +79,8 @@ async function check() {
       'extract', 'change',
       '--config', config,
       '--system', system,
-      '--base', `origin/${base}`,
-      '--head', `origin/${head}`,
+      '--base', base,
+      '--head', head,
       '--output', `./change-${uuid}.db`,
     ]);
 

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: '2025-05-29-3b8ec05'
+    default: '2025-06-17-bbafd00'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to remove the hard-coded `origin/` branch prefixes in check-pr now that we automatically fall back to `origin/` when necessary. https://github.com/appgardenstudios/hyaline/issues/137

# Changes
- Removes the `origin/` prefix on the branch names
- Bumps the default version to one with fallback support: [2025-06-17-bbafd00](https://github.com/appgardenstudios/hyaline/releases/tag/2025-06-17-bbafd00) 

# Testing
Update to the latest version of `setup` and `check-pr` and run check-pr