### PR TITLE
Open Beta - changes - separate git reference and alias arguments

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: '2025-06-17-bbafd00'
+    default: '2025-07-02-64bc3d4'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump the default version of hyaline so we are using the latest base and head resolution logic. https://github.com/appgardenstudios/hyaline/issues/155

# Changes
- Bump the default version of hyaline

# Testing
Use the setup action without specifying a version of hyaline and verify that it uses the new default