### PR TITLE
Release - WWW Go Live

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: '2025-07-02-64bc3d4'
+    default: '2025-07-04-a526e71'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump the default version of Hyaline to align with the release as specced in https://github.com/appgardenstudios/hyaline/issues/171.

# Changes
* Bump release to `2025-07-04-a526e71`

# Testing
Use the latest version of the setup action without specifying a version