### PR TITLE
Update the default version of hyaline to 2025-07-17-761cab1

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: '2025-07-04-a526e71'
+    default: '2025-07-17-761cab1'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to update the default version of hyaline to 2025-07-17-761cab1

# Changes
- Bumping the default version

# Testing
Update to the latest setup action and verify that it pulls the correct version of hyaline