### PR TITLE
Product and Process Support - Cleanup - version

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-08-08-47a12c2'
+    default: 'v1-2025-08-14-19f12de'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to increase the default hyaline version to the latest

# Changes
- Bump the version to `v1-2025-08-14-19f12de`

# Testing
- Verify that the setup script is outputting the correct version