### PR TITLE
Improve the recommendation and reason merging logic

### DIFF
--- a/check-pr/README.md
+++ b/check-pr/README.md
@@ -58,6 +58,7 @@ This action provides the following outputs:
 * `outstanding_recommendations` - The number of recommendations that are unchecked and not marked as completed.
 * `total_recommendations` - The total number of recommendations (sum of `completed_recommendations` and `outstanding_recommendations`)
 
+Note: Outdated recommendations are excluded from these recommendation numbers.
 
 # Developing
 

--- a/check-pr/dist/index.js
+++ b/check-pr/dist/index.js
@@ -31887,11 +31887,14 @@ async function check() {
     const recommendationsPath = path.join(process.cwd(), `./recommendations-${uuid}.json`);
     console.log(`Loading recommendations from ${recommendationsPath}`);
     const rawRecommendations = fs.readFileSync(recommendationsPath, 'utf8');
-    const recommendations = JSON.parse(rawRecommendations);
+    const allRecommendations = JSON.parse(rawRecommendations).recommendations;
+    // Exclude outdated recommendations
+    const recommendations = allRecommendations?.filter(rec => !rec.outdated);
+
     let completed_recommendations = 0;
     let outstanding_recommendations = 0;
-    let total_recommendations = recommendations.recommendations?.length || 0;
-    recommendations.recommendations?.forEach(rec => {
+    let total_recommendations = recommendations?.length || 0;
+    recommendations?.forEach(rec => {
       if (rec.checked) {
         completed_recommendations++;
       } else {

--- a/check-pr/index.js
+++ b/check-pr/index.js
@@ -58,11 +58,14 @@ async function check() {
     const recommendationsPath = path.join(process.cwd(), `./recommendations-${uuid}.json`);
     console.log(`Loading recommendations from ${recommendationsPath}`);
     const rawRecommendations = fs.readFileSync(recommendationsPath, 'utf8');
-    const recommendations = JSON.parse(rawRecommendations);
+    const allRecommendations = JSON.parse(rawRecommendations).recommendations;
+    // Exclude outdated recommendations
+    const recommendations = allRecommendations?.filter(rec => !rec.outdated);
+
     let completed_recommendations = 0;
     let outstanding_recommendations = 0;
-    let total_recommendations = recommendations.recommendations?.length || 0;
-    recommendations.recommendations?.forEach(rec => {
+    let total_recommendations = recommendations?.length || 0;
+    recommendations?.forEach(rec => {
       if (rec.checked) {
         completed_recommendations++;
       } else {

--- a/setup/README.md
+++ b/setup/README.md
@@ -23,7 +23,7 @@ steps:
 # Inputs
 The action supports the following inputs:
 
-* `version` - (optional) The version of the Hyaline CLI to install. This version must be present as a tagged [GitHub Release](https://github.com/appgardenstudios/hyaline/releases) and must be later than `v1-2025-08-08`.
+* `version` - (optional) The version of the Hyaline CLI to install. This version must be present as a tagged [GitHub Release](https://github.com/appgardenstudios/hyaline/releases) and must be later than `v1-2025-08-21`.
 
 # Outputs
 This action is not configured to provide any outputs.

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-08-14-19f12de'
+    default: 'v1-2025-08-21-aa6d234'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to update the version of hyaline to `v1-2025-08-21-aa6d234`, which includes a change to improve how recommendations are merged

# Changes
- Updated check-pr to ignore outdated recommendations
- Updated check-pr README.md to note that outdated recommendations are excluded
- Updated default hyaline version
- Updated setup README.md to indicate the minimum acceptable version, since this is not a backwards-compatible change

# Testing
- Make changes in this PR (or another that uses the new code) that will raise a recommendation and then undo that change. The recommendation should not be included in output numbers