### PR TITLE
Release v1-2025-08-22-6b7eba7

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-08-21-aa6d234'
+    default: 'v1-2025-08-22-6b7eba7'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to release the changes in https://github.com/appgardenstudios/hyaline/pull/283 under release v1-2025-08-22-6b7eba7.

# Changes
* Bump default version to `v1-2025-08-22-6b7eba7`

# Testing
See checks below