### PR TITLE
hyaline-actions cleanup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 npm run build
+
+git add ./*/dist/index.js

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ This action installs and sets up the Hyaline CLI in your GitHub action workflow.
 
 ## appgardenstudios/hyaline-actions/check-pr
 This action extracts and checks the change associated with a PR in your GitHub action workflow. Please visit the action's [README.md](./check-pr/README.md) for more information.
+
+## Releasing
+To release v1, checkout the main branch to the desired commit and run `./scripts/release-v1.sh`

--- a/scripts/release-v1.sh
+++ b/scripts/release-v1.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+git tag -d v1
+git push --delete origin v1
+git tag -a v1 -m "v1"
+git push origin v1


### PR DESCRIPTION
# Purpose
The purpose of this change is to cleanup hyaline-actions per https://github.com/appgardenstudios/hyaline/issues/286.

# Changes
- Add built artifacts after running build on the precommit hook
- Create `scripts/release-v1.sh` script and add it to the README

# Testing
Run `scripts/release-v1.sh` on the main branch on the current v1 tagged commit to tag a new release.