### PR TITLE
LLM Provider Support - GitHub Models + OpenAI - bump default version

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -23,7 +23,7 @@ steps:
 # Inputs
 The action supports the following inputs:
 
-* `version` - (optional) The version of the Hyaline CLI to install. This version must be present as a tagged [GitHub Release](https://github.com/appgardenstudios/hyaline/releases) and must be later than `v1-2025-08-21`.
+* `version` - (optional) The version of the Hyaline CLI to install. This version must be present as a tagged [GitHub Release](https://github.com/appgardenstudios/hyaline/releases) and must be later than `v1-2025-09-09`.
 
 # Outputs
 This action is not configured to provide any outputs.

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-05-c5447c8'
+    default: 'v1-2025-09-09-a947de5'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump the default version of hyaline to add support for GitHub Models and OpenAI. See https://github.com/appgardenstudios/hyaline/issues/281

# Changes
- Bumped the default version to v1-2025-09-09-a947de5
- Updated README minimum version

# Testing
Verify the setup action completes successfully with the correct version