### PR TITLE
Update Hyaline Version

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-09-a947de5'
+    default: 'v1-2025-09-12-e68ba97'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to update the default version of Hyaline to be v1-2025-09-12-e68ba97 per https://github.com/appgardenstudios/hyaline/issues/308.

# Changes
* Bump version

# Testing
See tests below