### PR TITLE
Bump hyaline version to v1-2025-09-17-def67f8

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-12-e68ba97'
+    default: 'v1-2025-09-17-def67f8'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump the hyaline version to v1-2025-09-17-def67f8. See: https://github.com/appgardenstudios/hyaline/releases/tag/v1-2025-09-17-def67f8

# Changes
- Bump hyaline version

# Testing
Verify setup installs the right version