### PR TITLE
Bump Hyaline to v1-2025-09-18-15be528

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-17-def67f8'
+    default: 'v1-2025-09-18-15be528'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to release the changes in https://github.com/appgardenstudios/hyaline/issues/301.

# Changes
* Bump Hyaline version to v1-2025-09-18-15be528

# Testing
See automated tests below