### PR TITLE
Bump hyaline to v1-2025-09-19-9e01153

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-18-15be528'
+    default: 'v1-2025-09-19-9e01153'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump hyaline to [v1-2025-09-19-9e01153.](https://github.com/appgardenstudios/hyaline/releases/tag/v1-2025-09-19-9e01153)

# Changes
- Bump default hyaline version

# Testing
Verify that setup action shows the right version