### PR TITLE
Bump hyaline to v1-2025-09-24-366c273

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-19-9e01153'
+    default: 'v1-2025-09-24-366c273'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump the latest version of hyaline. See: https://github.com/appgardenstudios/hyaline/releases/tag/v1-2025-09-24-366c273

# Changes
- Bump default hyaline version to v1-2025-09-24-366c273

# Testing
Verify that the setup script runs and shows the correct version