### PR TITLE
Bump hyaline to v1-2025-10-02-2cba591

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup Hyaline'
 inputs:
   version:
     description: 'The version to install'
-    default: 'v1-2025-09-24-366c273'
+    default: 'v1-2025-10-02-2cba591'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Purpose
The purpose of this change is to bump the version of Hyaline to https://github.com/appgardenstudios/hyaline/releases/tag/v1-2025-10-02-2cba591

# Changes
- Bump version

# Testing
Check setup script and verify the correct version is showing